### PR TITLE
add the default tab settings

### DIFF
--- a/src/main/kotlin/com/looker/droidify/content/Preferences.kt
+++ b/src/main/kotlin/com/looker/droidify/content/Preferences.kt
@@ -35,6 +35,7 @@ object Preferences {
         Key.RootPermission,
         Key.SortOrder,
         Key.Theme,
+        Key.DefaultTab,
         Key.UpdateNotify,
         Key.UpdateUnstable
     ).map { Pair(it.name, it) }.toMap()
@@ -169,6 +170,12 @@ object Preferences {
             )
         )
 
+        object DefaultTab : Key<Preferences.DefaultTab>(
+            "default_tab", Value.EnumerationValue(
+                Preferences.DefaultTab.Explore
+            )
+        )
+
         object UpdateNotify : Key<Boolean>("update_notify", Value.BooleanValue(true))
         object UpdateUnstable : Key<Boolean>("update_unstable", Value.BooleanValue(false))
     }
@@ -234,6 +241,25 @@ object Preferences {
 
         object Amoled : Theme("amoled") {
             override fun getResId(configuration: Configuration): Int = R.style.Theme_Main_Amoled
+        }
+    }
+
+    sealed class DefaultTab(override val valueString: String) : Enumeration<DefaultTab> {
+        override val values: List<DefaultTab>
+            get() = listOf(Explore, Latest, Installed)
+
+        abstract fun getResId(configuration: Configuration): Int
+
+        object Explore : DefaultTab("explore") {
+            override fun getResId(configuration: Configuration): Int = R.id.exploreTab
+        }
+
+        object Latest : DefaultTab("latest") {
+            override fun getResId(configuration: Configuration): Int = R.id.latestTab
+        }
+
+        object Installed : DefaultTab("installed") {
+            override fun getResId(configuration: Configuration): Int = R.id.installedTab
         }
     }
 

--- a/src/main/kotlin/com/looker/droidify/ui/activities/MainActivityX.kt
+++ b/src/main/kotlin/com/looker/droidify/ui/activities/MainActivityX.kt
@@ -68,9 +68,11 @@ class MainActivityX : AppCompatActivity() {
         get() = (application as MainApplication).db
 
     var currentTheme by Delegates.notNull<Int>()
+    var currentTab by Delegates.notNull<Int>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         currentTheme = Preferences[Preferences.Key.Theme].getResId(resources.configuration)
+        currentTab = Preferences[Preferences.Key.DefaultTab].getResId(resources.configuration)
         setTheme(currentTheme)
         super.onCreate(savedInstanceState)
         binding = ActivityMainXBinding.inflate(layoutInflater)
@@ -79,20 +81,7 @@ class MainActivityX : AppCompatActivity() {
         binding.lifecycleOwner = this
         toolbar = binding.toolbar
 
-        if (savedInstanceState == null && (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0) {
-            handleIntent(intent)
-        }
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-    }
-
-    override fun onStart() {
-        super.onStart()
         setSupportActionBar(toolbar)
-        if (Android.sdk(28) && !Android.Device.isHuaweiEmui) {
-            toolbar.menu.setGroupDividerEnabled(true)
-        }
-        toolbar.isFocusableInTouchMode = true
-        toolbar.title = getString(R.string.application_name)
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.fragment_content) as NavHostFragment
@@ -103,6 +92,21 @@ class MainActivityX : AppCompatActivity() {
             setOf(R.id.exploreTab, R.id.latestTab, R.id.installedTab)
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
+        binding.bottomNavigation.selectedItemId = currentTab
+
+        if (savedInstanceState == null && (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0) {
+            handleIntent(intent)
+        }
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (Android.sdk(28) && !Android.Device.isHuaweiEmui) {
+            toolbar.menu.setGroupDividerEnabled(true)
+        }
+        toolbar.isFocusableInTouchMode = true
+        toolbar.title = getString(R.string.application_name)
 
         supportFragmentManager.addFragmentOnAttachListener { _, _ ->
             hideKeyboard()

--- a/src/main/kotlin/com/looker/droidify/ui/fragments/PrefsUserFragment.kt
+++ b/src/main/kotlin/com/looker/droidify/ui/fragments/PrefsUserFragment.kt
@@ -37,6 +37,13 @@ class PrefsUserFragment : PrefsNavFragmentX() {
                     is Preferences.Theme.Amoled -> getString(R.string.amoled)
                 }
             }
+            addEnumeration(Preferences.Key.DefaultTab, getString(R.string.default_tab)) {
+                when (it) {
+                    is Preferences.DefaultTab.Explore -> getString(R.string.explore)
+                    is Preferences.DefaultTab.Latest -> getString(R.string.latest)
+                    is Preferences.DefaultTab.Installed -> getString(R.string.installed)
+                }
+            }
             addSwitch(
                 Preferences.Key.ListAnimation, getString(R.string.list_animation),
                 getString(R.string.list_animation_description)

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -186,4 +186,5 @@
     <string name="prefs_updated_apps">Number of updated apps to show</string>
     <string name="prefs_new_apps">Number of new apps to show</string>
     <string name="new_repository">New repository</string>
+    <string name="default_tab">Default Tab</string>
 </resources>


### PR DESCRIPTION
Add an option to set the initial tab of the app. https://github.com/Iamlooker/Droid-ify/issues/137
There has been no sudden change except on the MainActivityX.kt, I needed to move the bottomNavigation from onStart to onCreate, in this way the app will load the default tab only the first time the app initiates instead of when you go back to the activity, let me know if there is better way to do this, I'm very beginner with Kotlin.