### PR TITLE
Sort F-Droid categories by name

### DIFF
--- a/src/main/kotlin/com/looker/droidify/database/DAOs.kt
+++ b/src/main/kotlin/com/looker/droidify/database/DAOs.kt
@@ -224,7 +224,8 @@ interface CategoryDao : BaseDao<Category> {
         FROM category AS category
         JOIN repository AS repository
         ON category.repository_id = repository._id
-        WHERE repository.enabled != 0"""
+        WHERE repository.enabled != 0
+        ORDER BY category.name"""
     )
     val allNames: List<String>
 
@@ -233,7 +234,8 @@ interface CategoryDao : BaseDao<Category> {
         FROM category AS category
         JOIN repository AS repository
         ON category.repository_id = repository._id
-        WHERE repository.enabled != 0"""
+        WHERE repository.enabled != 0
+        ORDER BY category.name"""
     )
     val allNamesLive: LiveData<List<String>>
 


### PR DESCRIPTION
In the Explore tab, the category names were unsorted and this may be a little tedious if the user want to search a specific category, sort it to find categories easier.