### PR TITLE
Version timing info for apps

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -1159,10 +1159,10 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 					}
 					holder.version.text = versionString
 				} else {
-					holder.version.text = "Unknown Version"
+					holder.version.text = context.getString(stringRes.version_error)
 				}
 
-				var versionTime = product?.displayRelease?.added
+				val versionTime = product?.displayRelease?.added
 				if (versionTime != null) {
 					try {
 						val releasedTime = LocalDateTime.ofInstant(
@@ -1171,10 +1171,10 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 						)
 						val releasedDaysAgo = Duration.between(releasedTime, LocalDateTime.now()).toDays()
 						holder.version_recency.text = when (releasedDaysAgo) {
-							0L -> "Today"
-							1L -> "Yesterday"
-							in 2..100 -> "$releasedDaysAgo days ago"
-							else -> "${(releasedDaysAgo) / 30} months ago"
+							0L -> context.getString(stringRes.version_recency_today)
+							1L -> context.getString(stringRes.version_recency_yesterday)
+							in 2..100 -> context.getString(stringRes.version_recency_days_format, releasedDaysAgo)
+							else -> context.getString(stringRes.version_recency_months_format, releasedDaysAgo / 30)
 						}
 					} catch (e: Exception) {
 						Log.e(
@@ -1186,7 +1186,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 						holder.version_recency.text = "$versionTime"
 					}
 				} else {
-					holder.version_recency.text = "Upload time unknown"
+					holder.version_recency.text = context.getString(stringRes.version_recency_error)
 				}
 
 				holder.size.text = product?.displayRelease?.size?.formatSize()

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -69,6 +69,7 @@ import com.looker.droidify.utility.extension.resources.setTextSizeScaled
 import com.looker.droidify.utility.extension.resources.sizeScaled
 import com.looker.droidify.widget.StableRecyclerAdapter
 import java.lang.ref.WeakReference
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -366,6 +367,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 		val divider1 = itemView.findViewById<MaterialDivider>(R.id.divider1)!!
 		val targetSdk = itemView.findViewById<MaterialTextView>(R.id.sdk)!!
 		val version = itemView.findViewById<MaterialTextView>(R.id.version)!!
+		val version_recency = itemView.findViewById<MaterialTextView>(R.id.version_recency)!!
 		val size = itemView.findViewById<MaterialTextView>(R.id.size)!!
 		val dev = itemView.findViewById<MaterialCardView>(R.id.dev_block)!!
 	}
@@ -1149,7 +1151,44 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 				}
 
 				holder.targetSdk.text = sdk.toString()
-				holder.version.text = product?.displayRelease?.version
+
+				var versionString = product?.displayRelease?.version
+				if (versionString != null) {
+					if (Regex("^[0-9]").containsMatchIn(versionString)) {
+						versionString = "v${versionString}"
+					}
+					holder.version.text = versionString
+				} else {
+					holder.version.text = "Unknown Version"
+				}
+
+				var versionTime = product?.displayRelease?.added
+				if (versionTime != null) {
+					try {
+						val releasedTime = LocalDateTime.ofInstant(
+							Instant.ofEpochMilli(versionTime),
+							TimeZone.getDefault().toZoneId()
+						)
+						val releasedDaysAgo = Duration.between(releasedTime, LocalDateTime.now()).toDays()
+						holder.version_recency.text = when (releasedDaysAgo) {
+							0L -> "Today"
+							1L -> "Yesterday"
+							in 2..100 -> "$releasedDaysAgo days ago"
+							else -> "${(releasedDaysAgo) / 30} months ago"
+						}
+					} catch (e: Exception) {
+						Log.e(
+							"AppDetailAdapter",
+							"onBindViewHolder: Date cannot be formatted locally",
+							e
+						)
+						e.printStackTrace()
+						holder.version_recency.text = "$versionTime"
+					}
+				} else {
+					holder.version_recency.text = "Upload time unknown"
+				}
+
 				holder.size.text = product?.displayRelease?.size?.formatSize()
 
 				holder.dev.setOnClickListener {

--- a/app/src/main/res/layout/item_app_info_x.xml
+++ b/app/src/main/res/layout/item_app_info_x.xml
@@ -99,14 +99,16 @@
                 android:padding="16dp">
 
                 <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/version"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/version"
+                    android:ellipsize="marquee"
+                    android:singleLine="true"
                     android:textColor="?android:attr/textColorPrimary"
                     android:textSize="14sp" />
 
                 <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/version"
+                    android:id="@+id/version_recency"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:ellipsize="marquee"

--- a/core-common/src/main/res/values/strings.xml
+++ b/core-common/src/main/res/values/strings.xml
@@ -181,6 +181,12 @@
     <string name="username">Username</string>
     <string name="username_missing">Username missing</string>
     <string name="validation_index_error_DESC">Index could not be validated.</string>
+    <string name="version_error">Unknown version</string>
+    <string name="version_recency_error">Unknown upload time</string>
+    <string name="version_recency_today">Today</string>
+    <string name="version_recency_yesterday">Yesterday</string>
+    <string name="version_recency_days_format">%s days ago</string>
+    <string name="version_recency_months_format">%s months ago</string>
     <string name="version_FORMAT">Version %s</string>
     <string name="versions">Versions</string>
     <string name="waiting_to_start_download">Waiting to start download…</string>

--- a/core-common/src/main/res/values/strings.xml
+++ b/core-common/src/main/res/values/strings.xml
@@ -181,7 +181,6 @@
     <string name="username">Username</string>
     <string name="username_missing">Username missing</string>
     <string name="validation_index_error_DESC">Index could not be validated.</string>
-    <string name="version">Version</string>
     <string name="version_FORMAT">Version %s</string>
     <string name="versions">Versions</string>
     <string name="waiting_to_start_download">Waiting to start download…</string>


### PR DESCRIPTION
Part of #73 

It is not fully translated of course. Also, there are zombie translations of a key I removed hanging around that should probably be deleted. I will probably do this shortly after opening the PR.

Screenshots (I took a lot because I think how instant this makes some of this interesting information accessible is part of the appeal, I had fun taking them)

![Screenshot_2022-10-14_01-46-06](https://user-images.githubusercontent.com/75949275/195781380-c26a5b0d-54c7-4a0b-b471-0384818732fa.png)
![Screenshot_2022-10-14_01-46-28](https://user-images.githubusercontent.com/75949275/195781388-0b5c0a50-65ae-43f6-8593-8909959b3cdd.png)
![Screenshot_2022-10-14_01-48-38](https://user-images.githubusercontent.com/75949275/195781392-ecc470be-ca08-42db-a08c-b8b22dab4d8c.png)
![Screenshot_2022-10-14_01-48-11](https://user-images.githubusercontent.com/75949275/195781390-cdb6be09-6482-48d2-a1cf-25c448b17c8b.png)
