### PR TITLE
Move 'ignore new version' checkbox to below the versions

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -601,25 +601,6 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 				}
 			}
 
-			if (installedItem != null) {
-				items.add(
-					Item.SwitchItem(
-						SwitchType.IGNORE_ALL_UPDATES,
-						packageName,
-						productRepository.first.versionCode
-					)
-				)
-				if (productRepository.first.canUpdate(installedItem)) {
-					items.add(
-						Item.SwitchItem(
-							SwitchType.IGNORE_THIS_UPDATE,
-							packageName,
-							productRepository.first.versionCode
-						)
-					)
-				}
-			}
-
 			val textViewHolder = TextViewHolder(context)
 			val textViewWidthSpec = context.resources.displayMetrics.widthPixels
 				.let { View.MeasureSpec.makeMeasureSpec(it, View.MeasureSpec.EXACTLY) }
@@ -828,6 +809,25 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 							0
 						)
 					}
+				}
+			}
+
+			if (installedItem != null) {
+				items.add(
+					Item.SwitchItem(
+						SwitchType.IGNORE_ALL_UPDATES,
+						packageName,
+						productRepository.first.versionCode
+					)
+				)
+				if (productRepository.first.canUpdate(installedItem)) {
+					items.add(
+						Item.SwitchItem(
+							SwitchType.IGNORE_THIS_UPDATE,
+							packageName,
+							productRepository.first.versionCode
+						)
+					)
 				}
 			}
 		}

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -811,25 +811,6 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 					}
 				}
 			}
-
-			if (installedItem != null) {
-				items.add(
-					Item.SwitchItem(
-						SwitchType.IGNORE_ALL_UPDATES,
-						packageName,
-						productRepository.first.versionCode
-					)
-				)
-				if (productRepository.first.canUpdate(installedItem)) {
-					items.add(
-						Item.SwitchItem(
-							SwitchType.IGNORE_THIS_UPDATE,
-							packageName,
-							productRepository.first.versionCode
-						)
-					)
-				}
-			}
 		}
 
 		val compatibleReleasePairs = products.asSequence()
@@ -867,6 +848,25 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 				)
 			} else {
 				items += releaseItems
+			}
+		}
+
+		if (productRepository != null && installedItem != null) {
+			items.add(
+				Item.SwitchItem(
+					SwitchType.IGNORE_ALL_UPDATES,
+					packageName,
+					productRepository.first.versionCode
+				)
+			)
+			if (productRepository.first.canUpdate(installedItem)) {
+				items.add(
+					Item.SwitchItem(
+						SwitchType.IGNORE_THIS_UPDATE,
+						packageName,
+						productRepository.first.versionCode
+					)
+				)
 			}
 		}
 


### PR DESCRIPTION
This feels like a not-commonly-used UI interaction, certainly not more important than the description and not locally related to screenshots or description. Moving it all the way down makes the most sense I think.

Resolves #118 

Screenshot:

![Screenshot_2022-10-14_02-22-39](https://user-images.githubusercontent.com/75949275/195787357-d3fc3880-a700-4d86-9098-94e549aa4ab7.png)
