### PR TITLE
Remove screenshot bar

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -583,22 +583,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
 			if (productRepository.first.screenshots.isNotEmpty()) {
 				expanded += ExpandType.SCREENSHOTS
-				if (ExpandType.SCREENSHOTS in expanded) {
-					items += Item.SectionItem(
-						SectionType.SCREENSHOTS,
-						ExpandType.SCREENSHOTS,
-						emptyList(),
-						screenShotItem.size
-					)
-					items += screenShotItem
-				} else {
-					items += Item.SectionItem(
-						SectionType.SCREENSHOTS,
-						ExpandType.SCREENSHOTS,
-						screenShotItem,
-						0
-					)
-				}
+				items += screenShotItem
 			}
 
 			if (installedItem != null) {

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -563,7 +563,8 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 		context: Context, packageName: String,
 		products: List<Pair<Product, Repository>>,
 		installedItem: InstalledItem?,
-		incompatible: Boolean
+		showIncompatible: Boolean,
+		displayScreenshots: Boolean,
 	) {
 		val productRepository = Product.findSuggested(products, installedItem) { it.first }
 		items.clear()
@@ -574,8 +575,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 				productRepository.first
 			)
 
-			val displayScreenshots = true
-			if (displayScreenshots) { // TODO add preference
+			if (displayScreenshots) {
 				val screenShotItem = mutableListOf<Item>()
 				screenShotItem += Item.ScreenshotItem(
 					productRepository.first.screenshots,
@@ -823,7 +823,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 		val compatibleReleasePairs = products.asSequence()
 			.flatMap { (product, repository) ->
 				product.releases.asSequence()
-					.filter { incompatible || it.incompatibilities.isEmpty() }
+					.filter { showIncompatible || it.incompatibilities.isEmpty() }
 					.map { Pair(it, repository) }
 			}
 			.toList()

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -574,16 +574,18 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 				productRepository.first
 			)
 
-			val screenShotItem = mutableListOf<Item>()
-			screenShotItem += Item.ScreenshotItem(
-				productRepository.first.screenshots,
-				packageName,
-				productRepository.second
-			)
+			if (true) { // TODO add preference
+				val screenShotItem = mutableListOf<Item>()
+				screenShotItem += Item.ScreenshotItem(
+					productRepository.first.screenshots,
+					packageName,
+					productRepository.second
+				)
 
-			if (productRepository.first.screenshots.isNotEmpty()) {
-				expanded += ExpandType.SCREENSHOTS
-				items += screenShotItem
+				if (productRepository.first.screenshots.isNotEmpty()) {
+					expanded += ExpandType.SCREENSHOTS
+					items += screenShotItem
+				}
 			}
 
 			if (installedItem != null) {

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -574,7 +574,8 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 				productRepository.first
 			)
 
-			if (true) { // TODO add preference
+			val displayScreenshots = true
+			if (displayScreenshots) { // TODO add preference
 				val screenShotItem = mutableListOf<Item>()
 				screenShotItem += Item.ScreenshotItem(
 					productRepository.first.screenshots,

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -119,7 +119,6 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 		LINKS(stringRes.links, R.attr.colorPrimary),
 		DONATE(stringRes.donate, R.attr.colorPrimary),
 		PERMISSIONS(stringRes.permissions, R.attr.colorPrimary),
-		SCREENSHOTS(stringRes.screenshots, R.attr.colorPrimary),
 		VERSIONS(stringRes.versions, R.attr.colorPrimary)
 	}
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
@@ -243,7 +243,8 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 									packageName,
 									products,
 									installedItem.value,
-									initial.incompatibleVersions
+									initial.incompatibleVersions,
+									initial.displayScreenshots,
 								)
 								launch {
 									userPreferencesFlow.collectLatest {
@@ -252,7 +253,8 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 											packageName,
 											products,
 											installedItem.value,
-											it.incompatibleVersions
+											it.incompatibleVersions,
+											it.displayScreenshots,
 										)
 									}
 								}

--- a/core-common/src/main/res/values/strings.xml
+++ b/core-common/src/main/res/values/strings.xml
@@ -70,6 +70,8 @@
     <string name="incompatible_version">Incompatible version</string>
     <string name="incompatible_versions">Incompatible versions</string>
     <string name="incompatible_versions_summary">Show application versions incompatible with the device</string>
+    <string name="display_screenshots">Display Screenshots</string>
+    <string name="display_screenshots_summary">Load and render screenshots of apps, if available</string>
     <string name="incompatible_with_FORMAT">Incompatible with %s</string>
     <string name="install">Install</string>
     <string name="install_types">Installation Types</string>

--- a/core-datastore/src/main/java/com/looker/core_datastore/UserPreferencesRepository.kt
+++ b/core-datastore/src/main/java/com/looker/core_datastore/UserPreferencesRepository.kt
@@ -36,7 +36,8 @@ data class UserPreferences(
 	val proxyType: ProxyType,
 	val proxyHost: String,
 	val proxyPort: Int,
-	val cleanUpDuration: Duration
+	val cleanUpDuration: Duration,
+	var displayScreenshots: Boolean,
 )
 
 /**
@@ -51,6 +52,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
 	private object PreferencesKeys {
 		val LANGUAGE = stringPreferencesKey("key_language")
 		val INCOMPATIBLE_VERSIONS = booleanPreferencesKey("key_incompatible_versions")
+		val DISPLAY_SCREENSHOTS = booleanPreferencesKey("key_display_screenshots")
 		val NOTIFY_UPDATES = booleanPreferencesKey("key_notify_updates")
 		val UNSTABLE_UPDATES = booleanPreferencesKey("key_unstable_updates")
 		val THEME = stringPreferencesKey("key_theme")
@@ -85,6 +87,10 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
 	 */
 	suspend fun enableIncompatibleVersion(enable: Boolean) {
 		PreferencesKeys.INCOMPATIBLE_VERSIONS.update(enable)
+	}
+
+	suspend fun setDisplayScreenshots(enable: Boolean) {
+		PreferencesKeys.DISPLAY_SCREENSHOTS.update(enable)
 	}
 
 	/**
@@ -175,6 +181,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
 	private fun mapUserPreferences(preferences: Preferences): UserPreferences {
 		val language = preferences[PreferencesKeys.LANGUAGE] ?: "system"
 		val incompatibleVersions = preferences[PreferencesKeys.INCOMPATIBLE_VERSIONS] ?: false
+		val displayScreenshots = preferences[PreferencesKeys.DISPLAY_SCREENSHOTS] ?: true
 		val notifyUpdate = preferences[PreferencesKeys.NOTIFY_UPDATES] ?: true
 		val unstableUpdate = preferences[PreferencesKeys.UNSTABLE_UPDATES] ?: false
 		val theme = Theme.valueOf(
@@ -200,6 +207,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
 		return UserPreferences(
 			language = language,
 			incompatibleVersions = incompatibleVersions,
+			displayScreenshots = displayScreenshots,
 			notifyUpdate = notifyUpdate,
 			unstableUpdate = unstableUpdate,
 			theme = theme,

--- a/feature-settings/src/main/java/com/looker/feature_settings/SettingsFragment.kt
+++ b/feature-settings/src/main/java/com/looker/feature_settings/SettingsFragment.kt
@@ -73,6 +73,8 @@ class SettingsFragment : Fragment() {
 			unstableUpdates.content.text = getString(stringRes.unstable_updates_summary)
 			incompatibleUpdates.title.text = getString(stringRes.incompatible_versions)
 			incompatibleUpdates.content.text = getString(stringRes.incompatible_versions_summary)
+			displayScreenshots.title.text = getString(stringRes.display_screenshots)
+			displayScreenshots.content.text = getString(stringRes.display_screenshots_summary)
 			proxyType.title.text = getString(stringRes.proxy_type)
 			proxyHost.title.text = getString(stringRes.proxy_host)
 			proxyPort.title.text = getString(stringRes.proxy_port)
@@ -207,6 +209,9 @@ class SettingsFragment : Fragment() {
 				incompatibleUpdates.checked.setOnCheckedChangeListener { _, checked ->
 					setIncompatibleUpdates(checked)
 				}
+				displayScreenshots.checked.setOnCheckedChangeListener { _, checked ->
+					setDisplayScreenshots(checked)
+				}
 			}
 		}
 	}
@@ -268,6 +273,7 @@ class SettingsFragment : Fragment() {
 			notifyUpdates.checked.isChecked = userPreferences.notifyUpdate
 			unstableUpdates.checked.isChecked = userPreferences.unstableUpdate
 			incompatibleUpdates.checked.isChecked = userPreferences.incompatibleVersions
+			displayScreenshots.checked.isChecked = userPreferences.displayScreenshots
 			proxyType.content.text = context.proxyName(userPreferences.proxyType)
 			proxyType.root.setOnClickListener { view ->
 				view.addSingleCorrectDialog(

--- a/feature-settings/src/main/java/com/looker/feature_settings/SettingsViewModel.kt
+++ b/feature-settings/src/main/java/com/looker/feature_settings/SettingsViewModel.kt
@@ -67,6 +67,12 @@ class SettingsViewModel
 		}
 	}
 
+	fun setDisplayScreenshots(enable: Boolean) {
+		viewModelScope.launch {
+			userPreferencesRepository.setDisplayScreenshots(enable)
+		}
+	}
+
 	fun setProxyType(proxyType: ProxyType) {
 		viewModelScope.launch {
 			userPreferencesRepository.setProxyType(proxyType)

--- a/feature-settings/src/main/res/layout/settings_page.xml
+++ b/feature-settings/src/main/res/layout/settings_page.xml
@@ -66,6 +66,10 @@
                 android:id="@+id/clean_up"
                 layout="@layout/enum_type" />
 
+            <include
+                android:id="@+id/display_screenshots"
+                layout="@layout/switch_type" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
~~This is not quite yet ready to merge.~~ It is now.

As noted in the discussion, a preference has been added to not load screenshots - useful for low-network situations, or if you just hate pictures or something.

Should resolve #119