### PR TITLE
Completely removes the collapsing toolbar, as it just wastes space. Makes it not change as much when scrolling down in app as well.

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/screen/EditRepositoryFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/screen/EditRepositoryFragment.kt
@@ -93,7 +93,7 @@ class EditRepositoryFragment() : ScreenFragment() {
 		syncConnection.bind(requireContext())
 
 		screenActivity.onToolbarCreated(toolbar)
-		collapsingToolbar.title =
+		toolbar.title =
 			getString(if (repositoryId != null) stringRes.edit_repository else stringRes.add_repository)
 
 		saveMenuItem = toolbar.menu.add(stringRes.save)

--- a/app/src/main/kotlin/com/looker/droidify/screen/RepositoriesFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/screen/RepositoriesFragment.kt
@@ -45,7 +45,6 @@ class RepositoriesFragment : ScreenFragment(), CursorOwner.Callback {
 			)
 		}
 		this.toolbar = fragmentBinding.toolbar
-		this.collapsingToolbar = fragmentBinding.collapsingToolbar
 		return view
 	}
 
@@ -63,7 +62,7 @@ class RepositoriesFragment : ScreenFragment(), CursorOwner.Callback {
 				view.post { screenActivity.navigateAddRepository() }
 				true
 			}
-		collapsingToolbar.title = getString(stringRes.repositories)
+		toolbar.title = getString(stringRes.repositories)
 	}
 
 	override fun onDestroyView() {

--- a/app/src/main/kotlin/com/looker/droidify/screen/RepositoryFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/screen/RepositoryFragment.kt
@@ -55,7 +55,7 @@ class RepositoryFragment() : ScreenFragment() {
 		lifecycleScope.launch(Dispatchers.Main) { updateRepositoryView() }
 
 		screenActivity.onToolbarCreated(toolbar)
-		collapsingToolbar.title = getString(stringRes.repository)
+		toolbar.title = getString(stringRes.repository)
 
 		toolbar.menu.apply {
 			add(stringRes.edit_repository)
@@ -109,7 +109,7 @@ class RepositoryFragment() : ScreenFragment() {
 			layout.addTitleText(stringRes.address, getString(stringRes.unknown))
 		} else {
 			layout.addTitleText(stringRes.address, repository.address)
-			collapsingToolbar.title = repository.name
+			toolbar.title = repository.name
 			layout.addTitleText(stringRes.name, repository.name)
 			layout.addTitleText(
 				stringRes.description,

--- a/app/src/main/kotlin/com/looker/droidify/screen/ScreenFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/screen/ScreenFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.looker.droidify.databinding.FragmentBinding
@@ -14,7 +15,6 @@ open class ScreenFragment : Fragment() {
 	val fragmentBinding get() = _fragmentBinding!!
 
 	lateinit var toolbar: MaterialToolbar
-	lateinit var collapsingToolbar: CollapsingToolbarLayout
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -27,7 +27,6 @@ open class ScreenFragment : Fragment() {
 		savedInstanceState: Bundle?,
 	): View? {
 		this.toolbar = fragmentBinding.toolbar
-		this.collapsingToolbar = fragmentBinding.collapsingToolbar
 		return fragmentBinding.root
 	}
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
@@ -352,7 +352,11 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 
 	private suspend fun updateToolbarTitle() {
 		withContext(Dispatchers.Main) {
-			toolbar.title = products[0].first.name
+			val showPackageName = recyclerView
+				?.let { (it.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition() != 0 } == true
+			toolbar.title =
+				if (showPackageName) products[0].first.name
+				else ""
 		}
 	}
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
@@ -352,23 +352,14 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 
 	private suspend fun updateToolbarTitle() {
 		withContext(Dispatchers.Main) {
-			val showPackageName = recyclerView
-				?.let { (it.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition() != 0 } == true
-			collapsingToolbar.title =
-				if (showPackageName) products[0].first.name.trimAfter(' ', 2)
-				else getString(stringRes.application)
+			collapsingToolbar.title = products[0].first.name.trimAfter(' ', 2)
 		}
 	}
 
 	private suspend fun updateToolbarButtons() {
 		withContext(Dispatchers.Default) {
-			val (actions, primaryAction) = actions
-			val showPrimaryAction = recyclerView
-				?.let { (it.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition() != 0 } == true
+			val (actions, _) = actions
 			val displayActions = actions.toMutableSet()
-			if (!showPrimaryAction && primaryAction != null) {
-				displayActions -= primaryAction
-			}
 			if (displayActions.size >= 4 && resources.configuration.screenWidthDp < 400) {
 				displayActions -= Action.DETAILS
 			}

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
@@ -352,7 +352,7 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 
 	private suspend fun updateToolbarTitle() {
 		withContext(Dispatchers.Main) {
-			collapsingToolbar.title = products[0].first.name.trimAfter(' ', 2)
+			collapsingToolbar.title = products[0].first.name
 		}
 	}
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailFragment.kt
@@ -352,7 +352,7 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 
 	private suspend fun updateToolbarTitle() {
 		withContext(Dispatchers.Main) {
-			collapsingToolbar.title = products[0].first.name
+			toolbar.title = products[0].first.name
 		}
 	}
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/tabs_fragment/TabsFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/tabs_fragment/TabsFragment.kt
@@ -132,7 +132,7 @@ class TabsFragment : ScreenFragment() {
 		syncConnection.bind(requireContext())
 
 		screenActivity.onToolbarCreated(toolbar)
-		collapsingToolbar.title = getString(R.string.application_name)
+		toolbar.title = getString(R.string.application_name)
 		// Move focus from SearchView to Toolbar
 		toolbar.isFocusableInTouchMode = true
 

--- a/app/src/main/res/layout/fragment.xml
+++ b/app/src/main/res/layout/fragment.xml
@@ -14,21 +14,13 @@
         app:elevation="0dp"
         app:liftOnScroll="false">
 
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsing_toolbar"
-            style="?attr/collapsingToolbarLayoutLargeStyle"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            style="?attr/toolbarStyle"
             android:layout_width="match_parent"
-            android:layout_height="?attr/collapsingToolbarLayoutLargeSize"
-            app:layout_scrollFlags="scroll|snap|exitUntilCollapsed">
-
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
-                style="?attr/toolbarStyle"
-                android:layout_width="match_parent"
-                android:layout_height="?actionBarSize"
-                android:background="?colorSurface"
-                android:elevation="0dp" />
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
+            android:layout_height="?actionBarSize"
+            android:background="?colorSurface"
+            android:elevation="0dp" />
 
         <FrameLayout
             android:id="@+id/toolbar_extra"

--- a/core-common/src/main/res/values/strings.xml
+++ b/core-common/src/main/res/values/strings.xml
@@ -9,7 +9,6 @@
     <string name="always">Always</string>
     <string name="amoled">Black</string>
     <string name="anti_features">Anti-features</string>
-    <string name="application">Application</string>
     <string name="application_not_found">Could not find that application</string>
     <string name="author_email">Author e-mail</string>
     <string name="author_website">Author website</string>


### PR DESCRIPTION
Unsure if this should be merged - I think it is an objectively better UI experience in all aspects, but it removes a tiny bit of flair the app had.

Would resolve #32 - while no one in that discussion seemed to like the toolbar, but it should be noted that issue requested an option to enable/disable it, while this just removes it entirely.