### PR TITLE
Implementation of dynamic "Material You" colors

### DIFF
--- a/core/common/src/main/res/values-v31/styles.xml
+++ b/core/common/src/main/res/values-v31/styles.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="Theme.Main.Light" parent="Theme.Material3.Light.NoActionBar">
+        <item name="colorPrimary">@android:color/system_accent1_400</item>
+        <item name="colorOnPrimary">@android:color/system_accent1_0</item>
+        <item name="colorPrimaryContainer">@android:color/system_accent1_200</item>
+        <item name="colorOnPrimaryContainer">@android:color/system_accent1_900</item>
+        <item name="colorSecondary">@android:color/system_accent3_700</item>
+        <item name="colorOnSecondary">@android:color/system_accent3_0</item>
+        <item name="colorSecondaryContainer">@android:color/system_accent3_200</item>
+        <item name="colorOnSecondaryContainer">@android:color/system_accent3_900</item>
+        <item name="colorError">@color/md_theme_light_error</item>
+        <item name="colorErrorContainer">@color/md_theme_light_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_light_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_light_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_light_background</item>
+        <item name="colorOnBackground">@color/md_theme_light_onBackground</item>
+        <item name="colorSurface">@android:color/system_neutral1_100</item>
+        <item name="colorOnSurface">@android:color/system_neutral1_900</item>
+        <item name="colorSurfaceVariant">@android:color/system_neutral2_100</item>
+        <item name="colorOnSurfaceVariant">@android:color/system_neutral2_700</item>
+        <item name="colorOutline">@android:color/system_neutral2_500</item>
+        <item name="colorOnSurfaceInverse">@android:color/system_neutral1_100</item>
+        <item name="colorSurfaceInverse">@android:color/system_neutral1_900</item>
+        <item name="colorPrimaryInverse">@android:color/system_accent1_300</item>
+        <item name="android:statusBarColor">@color/md_theme_light_surface</item>
+        <item name="android:navigationBarColor">@color/md_theme_light_background</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
+
+        <item name="android:fastScrollThumbDrawable">@drawable/scrollbar_thumb</item>
+        <item name="android:fastScrollTrackDrawable">@drawable/scrollbar_track</item>
+
+        <item name="switchStyle">@style/Theme.Switch</item>
+        <item name="toolbarStyle">@style/Theme.Toolbar</item>
+        <item name="textInputStyle">@style/Theme.EditText</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
+        <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
+        <item name="materialCardViewStyle">@style/Theme.Card</item>
+        <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
+        <item name="collapsingToolbarLayoutLargeStyle">@style/Theme.CollapsingToolbar</item>
+        <item name="textAppearanceHeadlineMedium">@style/HeadlineMedium</item>
+        <item name="textAppearanceHeadlineSmall">@style/HeadlineSmall</item>
+    </style>
+
+    <style name="Theme.Main.Dark" parent="Theme.Material3.Dark.NoActionBar">
+        <item name="colorPrimary">@android:color/system_accent1_500</item>
+        <item name="colorOnPrimary">@android:color/system_accent1_800</item>
+        <item name="colorPrimaryContainer">@android:color/system_accent1_600</item>
+        <item name="colorOnPrimaryContainer">@android:color/system_accent1_300</item>
+        <item name="colorSecondary">@android:color/system_accent3_500</item>
+        <item name="colorOnSecondary">@android:color/system_accent3_800</item>
+        <item name="colorSecondaryContainer">@android:color/system_accent3_600</item>
+        <item name="colorOnSecondaryContainer">@android:color/system_accent3_300</item>
+        <item name="colorError">@color/md_theme_dark_error</item>
+        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_dark_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_dark_background</item>
+        <item name="colorOnBackground">@color/md_theme_dark_onBackground</item>
+        <item name="colorSurface">@color/grey_dark</item>
+        <item name="colorOnSurface">@color/md_theme_dark_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_dark_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_dark_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_dark_outline</item>
+        <item name="colorOnSurfaceInverse">@color/md_theme_dark_inverseOnSurface</item>
+        <item name="colorSurfaceInverse">@color/md_theme_dark_inverseSurface</item>
+        <item name="colorPrimaryInverse">@android:color/system_accent1_600</item>
+        <item name="android:statusBarColor">@android:color/system_neutral1_900</item>
+        <item name="android:navigationBarColor">@color/md_theme_dark_background</item>
+
+        <item name="android:fastScrollThumbDrawable">@drawable/scrollbar_thumb</item>
+        <item name="android:fastScrollTrackDrawable">@drawable/scrollbar_track</item>
+
+        <item name="switchStyle">@style/Theme.Switch</item>
+        <item name="toolbarStyle">@style/Theme.Toolbar</item>
+        <item name="textInputStyle">@style/Theme.EditText</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
+        <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
+        <item name="materialCardViewStyle">@style/Theme.Card</item>
+        <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
+        <item name="collapsingToolbarLayoutLargeStyle">@style/Theme.CollapsingToolbar</item>
+        <item name="textAppearanceHeadlineMedium">@style/HeadlineMedium</item>
+        <item name="textAppearanceHeadlineSmall">@style/HeadlineSmall</item>
+    </style>
+
+    <style name="Theme.Main.Amoled" parent="Theme.Material3.Dark.NoActionBar">
+        <item name="colorPrimary">@android:color/system_accent1_500</item>
+        <item name="colorOnPrimary">@android:color/system_accent1_800</item>
+        <item name="colorPrimaryContainer">@android:color/system_accent1_600</item>
+        <item name="colorOnPrimaryContainer">@android:color/system_accent1_300</item>
+        <item name="colorSecondary">@android:color/system_accent3_500</item>
+        <item name="colorOnSecondary">@android:color/system_accent3_800</item>
+        <item name="colorSecondaryContainer">@android:color/system_accent3_600</item>
+        <item name="colorOnSecondaryContainer">@android:color/system_accent3_300</item>
+        <item name="colorError">@color/md_theme_dark_error</item>
+        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_dark_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
+        <item name="colorSurface">@android:color/system_neutral1_900</item>
+        <item name="colorOnSurface">@android:color/system_neutral1_50</item>
+        <item name="colorSurfaceVariant">@android:color/system_neutral2_600</item>
+        <item name="colorOnSurfaceVariant">@android:color/system_neutral2_300</item>
+        <item name="colorOutline">@android:color/system_neutral2_500</item>
+        <item name="colorOnSurfaceInverse">@android:color/system_neutral1_900</item>
+        <item name="colorSurfaceInverse">@android:color/system_neutral1_100</item>
+        <item name="colorPrimaryInverse">@android:color/system_accent1_600</item>
+        <item name="android:colorBackground">@color/pitch_black</item>
+        <item name="colorOnBackground">@color/md_theme_dark_onBackground</item>
+        <item name="android:statusBarColor">@android:color/system_neutral1_900</item>
+        <item name="android:navigationBarColor">@color/pitch_black</item>
+
+        <item name="android:fastScrollThumbDrawable">@drawable/scrollbar_thumb</item>
+        <item name="android:fastScrollTrackDrawable">@drawable/scrollbar_track</item>
+
+        <item name="switchStyle">@style/Theme.Switch</item>
+        <item name="toolbarStyle">@style/Theme.Toolbar</item>
+        <item name="textInputStyle">@style/Theme.EditText</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
+        <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
+        <item name="materialCardViewStyle">@style/Theme.Card</item>
+        <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
+        <item name="collapsingToolbarLayoutLargeStyle">@style/Theme.CollapsingToolbar</item>
+        <item name="textAppearanceHeadlineMedium">@style/HeadlineMedium</item>
+        <item name="textAppearanceHeadlineSmall">@style/HeadlineSmall</item>
+    </style>
+
+</resources>
+
+
+
+
+

--- a/core/common/src/main/res/values-v31/styles.xml
+++ b/core/common/src/main/res/values-v31/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.Main.Light" parent="Theme.Material3.Light.NoActionBar">
+    <style name="Theme.Main.DynamicLight" parent="Theme.Main.Light">
         <item name="colorPrimary">@android:color/system_accent1_400</item>
         <item name="colorOnPrimary">@android:color/system_accent1_0</item>
         <item name="colorPrimaryContainer">@android:color/system_accent1_200</item>
@@ -10,12 +10,6 @@
         <item name="colorOnSecondary">@android:color/system_accent3_0</item>
         <item name="colorSecondaryContainer">@android:color/system_accent3_200</item>
         <item name="colorOnSecondaryContainer">@android:color/system_accent3_900</item>
-        <item name="colorError">@color/md_theme_light_error</item>
-        <item name="colorErrorContainer">@color/md_theme_light_errorContainer</item>
-        <item name="colorOnError">@color/md_theme_light_onError</item>
-        <item name="colorOnErrorContainer">@color/md_theme_light_onErrorContainer</item>
-        <item name="android:colorBackground">@color/md_theme_light_background</item>
-        <item name="colorOnBackground">@color/md_theme_light_onBackground</item>
         <item name="colorSurface">@android:color/system_neutral1_100</item>
         <item name="colorOnSurface">@android:color/system_neutral1_900</item>
         <item name="colorSurfaceVariant">@android:color/system_neutral2_100</item>
@@ -24,27 +18,9 @@
         <item name="colorOnSurfaceInverse">@android:color/system_neutral1_100</item>
         <item name="colorSurfaceInverse">@android:color/system_neutral1_900</item>
         <item name="colorPrimaryInverse">@android:color/system_accent1_300</item>
-        <item name="android:statusBarColor">@color/md_theme_light_surface</item>
-        <item name="android:navigationBarColor">@color/md_theme_light_background</item>
-        <item name="android:windowLightStatusBar">true</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
-
-        <item name="android:fastScrollThumbDrawable">@drawable/scrollbar_thumb</item>
-        <item name="android:fastScrollTrackDrawable">@drawable/scrollbar_track</item>
-
-        <item name="switchStyle">@style/Theme.Switch</item>
-        <item name="toolbarStyle">@style/Theme.Toolbar</item>
-        <item name="textInputStyle">@style/Theme.EditText</item>
-        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
-        <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
-        <item name="materialCardViewStyle">@style/Theme.Card</item>
-        <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
-        <item name="collapsingToolbarLayoutLargeStyle">@style/Theme.CollapsingToolbar</item>
-        <item name="textAppearanceHeadlineMedium">@style/HeadlineMedium</item>
-        <item name="textAppearanceHeadlineSmall">@style/HeadlineSmall</item>
     </style>
 
-    <style name="Theme.Main.Dark" parent="Theme.Material3.Dark.NoActionBar">
+    <style name="Theme.Main.DynamicDark" parent="Theme.Main.Dark">
         <item name="colorPrimary">@android:color/system_accent1_500</item>
         <item name="colorOnPrimary">@android:color/system_accent1_800</item>
         <item name="colorPrimaryContainer">@android:color/system_accent1_600</item>
@@ -53,39 +29,11 @@
         <item name="colorOnSecondary">@android:color/system_accent3_800</item>
         <item name="colorSecondaryContainer">@android:color/system_accent3_600</item>
         <item name="colorOnSecondaryContainer">@android:color/system_accent3_300</item>
-        <item name="colorError">@color/md_theme_dark_error</item>
-        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
-        <item name="colorOnError">@color/md_theme_dark_onError</item>
-        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
-        <item name="android:colorBackground">@color/md_theme_dark_background</item>
-        <item name="colorOnBackground">@color/md_theme_dark_onBackground</item>
-        <item name="colorSurface">@color/grey_dark</item>
-        <item name="colorOnSurface">@color/md_theme_dark_onSurface</item>
-        <item name="colorSurfaceVariant">@color/md_theme_dark_surfaceVariant</item>
-        <item name="colorOnSurfaceVariant">@color/md_theme_dark_onSurfaceVariant</item>
-        <item name="colorOutline">@color/md_theme_dark_outline</item>
-        <item name="colorOnSurfaceInverse">@color/md_theme_dark_inverseOnSurface</item>
-        <item name="colorSurfaceInverse">@color/md_theme_dark_inverseSurface</item>
         <item name="colorPrimaryInverse">@android:color/system_accent1_600</item>
         <item name="android:statusBarColor">@android:color/system_neutral1_900</item>
-        <item name="android:navigationBarColor">@color/md_theme_dark_background</item>
-
-        <item name="android:fastScrollThumbDrawable">@drawable/scrollbar_thumb</item>
-        <item name="android:fastScrollTrackDrawable">@drawable/scrollbar_track</item>
-
-        <item name="switchStyle">@style/Theme.Switch</item>
-        <item name="toolbarStyle">@style/Theme.Toolbar</item>
-        <item name="textInputStyle">@style/Theme.EditText</item>
-        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
-        <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
-        <item name="materialCardViewStyle">@style/Theme.Card</item>
-        <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
-        <item name="collapsingToolbarLayoutLargeStyle">@style/Theme.CollapsingToolbar</item>
-        <item name="textAppearanceHeadlineMedium">@style/HeadlineMedium</item>
-        <item name="textAppearanceHeadlineSmall">@style/HeadlineSmall</item>
     </style>
 
-    <style name="Theme.Main.Amoled" parent="Theme.Material3.Dark.NoActionBar">
+    <style name="Theme.Main.DynamicAmoled" parent="Theme.Main.Amoled">
         <item name="colorPrimary">@android:color/system_accent1_500</item>
         <item name="colorOnPrimary">@android:color/system_accent1_800</item>
         <item name="colorPrimaryContainer">@android:color/system_accent1_600</item>
@@ -94,10 +42,6 @@
         <item name="colorOnSecondary">@android:color/system_accent3_800</item>
         <item name="colorSecondaryContainer">@android:color/system_accent3_600</item>
         <item name="colorOnSecondaryContainer">@android:color/system_accent3_300</item>
-        <item name="colorError">@color/md_theme_dark_error</item>
-        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
-        <item name="colorOnError">@color/md_theme_dark_onError</item>
-        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
         <item name="colorSurface">@android:color/system_neutral1_900</item>
         <item name="colorOnSurface">@android:color/system_neutral1_50</item>
         <item name="colorSurfaceVariant">@android:color/system_neutral2_600</item>
@@ -106,24 +50,7 @@
         <item name="colorOnSurfaceInverse">@android:color/system_neutral1_900</item>
         <item name="colorSurfaceInverse">@android:color/system_neutral1_100</item>
         <item name="colorPrimaryInverse">@android:color/system_accent1_600</item>
-        <item name="android:colorBackground">@color/pitch_black</item>
-        <item name="colorOnBackground">@color/md_theme_dark_onBackground</item>
         <item name="android:statusBarColor">@android:color/system_neutral1_900</item>
-        <item name="android:navigationBarColor">@color/pitch_black</item>
-
-        <item name="android:fastScrollThumbDrawable">@drawable/scrollbar_thumb</item>
-        <item name="android:fastScrollTrackDrawable">@drawable/scrollbar_track</item>
-
-        <item name="switchStyle">@style/Theme.Switch</item>
-        <item name="toolbarStyle">@style/Theme.Toolbar</item>
-        <item name="textInputStyle">@style/Theme.EditText</item>
-        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
-        <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
-        <item name="materialCardViewStyle">@style/Theme.Card</item>
-        <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
-        <item name="collapsingToolbarLayoutLargeStyle">@style/Theme.CollapsingToolbar</item>
-        <item name="textAppearanceHeadlineMedium">@style/HeadlineMedium</item>
-        <item name="textAppearanceHeadlineSmall">@style/HeadlineSmall</item>
     </style>
 
 </resources>

--- a/core/database/schemas/com.looker.core.database.DroidifyDatabase/1.json
+++ b/core/database/schemas/com.looker.core.database.DroidifyDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "ae20ea0e83e31dd77a1decf445d1d83e",
+    "identityHash": "6a281e3bbf026efd3a036d1b16202290",
     "entities": [
       {
         "tableName": "apps",
@@ -213,7 +213,7 @@
       },
       {
         "tableName": "repos",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `fingerprint` TEXT NOT NULL, `etag` TEXT NOT NULL, `address` TEXT NOT NULL, `mirrors` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `version` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `icon` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `enabled` INTEGER NOT NULL, `fingerprint` TEXT NOT NULL, `etag` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `address` TEXT NOT NULL, `mirrors` BLOB NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `version` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -236,6 +236,18 @@
           {
             "fieldPath": "etag",
             "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -274,12 +286,6 @@
             "columnName": "timestamp",
             "affinity": "INTEGER",
             "notNull": true
-          },
-          {
-            "fieldPath": "icon",
-            "columnName": "icon",
-            "affinity": "TEXT",
-            "notNull": true
           }
         ],
         "primaryKey": {
@@ -295,7 +301,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ae20ea0e83e31dd77a1decf445d1d83e')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6a281e3bbf026efd3a036d1b16202290')"
     ]
   }
 }

--- a/core/datastore/src/main/java/com/looker/core/datastore/extension/Preferences.kt
+++ b/core/datastore/src/main/java/com/looker/core/datastore/extension/Preferences.kt
@@ -13,7 +13,7 @@ import com.looker.core.common.R.style as styleRes
 fun Context?.themeName(theme: Theme) = this?.let {
 	when (theme) {
 		Theme.SYSTEM -> getString(stringRes.system)
-		Theme.SYSTEM_BLACK -> getString(stringRes.system) + " " + getString(stringRes.amoled)
+		Theme.SYSTEM_AMOLED -> getString(stringRes.system) + " " + getString(stringRes.amoled)
 		Theme.LIGHT -> getString(stringRes.light)
 		Theme.DARK -> getString(stringRes.dark)
 		Theme.AMOLED -> getString(stringRes.amoled)
@@ -25,7 +25,7 @@ fun Configuration.getThemeRes(theme: Theme) = when (theme) {
 		if ((uiMode and Configuration.UI_MODE_NIGHT_YES) != 0)
 			styleRes.Theme_Main_Dark else styleRes.Theme_Main_Light
 	}
-	Theme.SYSTEM_BLACK -> {
+	Theme.SYSTEM_AMOLED -> {
 		if ((uiMode and Configuration.UI_MODE_NIGHT_YES) != 0)
 			styleRes.Theme_Main_Amoled else styleRes.Theme_Main_Light
 	}

--- a/core/datastore/src/main/java/com/looker/core/datastore/extension/Preferences.kt
+++ b/core/datastore/src/main/java/com/looker/core/datastore/extension/Preferences.kt
@@ -9,6 +9,7 @@ import com.looker.core.datastore.model.SortOrder
 import com.looker.core.datastore.model.Theme
 import com.looker.core.common.R.string as stringRes
 import com.looker.core.common.R.style as styleRes
+import com.looker.core.common.Util
 
 fun Context?.themeName(theme: Theme) = this?.let {
 	when (theme) {
@@ -23,11 +24,15 @@ fun Context?.themeName(theme: Theme) = this?.let {
 fun Configuration.getThemeRes(theme: Theme) = when (theme) {
 	Theme.SYSTEM -> {
 		if ((uiMode and Configuration.UI_MODE_NIGHT_YES) != 0)
-			styleRes.Theme_Main_Dark else styleRes.Theme_Main_Light
+			if (Util.isSnowCake) styleRes.Theme_Main_DynamicDark else styleRes.Theme_Main_Dark
+		else
+			if (Util.isSnowCake) styleRes.Theme_Main_DynamicLight else styleRes.Theme_Main_Light
 	}
 	Theme.SYSTEM_AMOLED -> {
 		if ((uiMode and Configuration.UI_MODE_NIGHT_YES) != 0)
-			styleRes.Theme_Main_Amoled else styleRes.Theme_Main_Light
+			if (Util.isSnowCake) styleRes.Theme_Main_DynamicAmoled else styleRes.Theme_Main_Amoled
+		else
+			if (Util.isSnowCake) styleRes.Theme_Main_DynamicLight else styleRes.Theme_Main_Light
 	}
 	Theme.LIGHT -> styleRes.Theme_Main_Light
 	Theme.DARK -> styleRes.Theme_Main_Dark

--- a/core/datastore/src/main/java/com/looker/core/datastore/model/Theme.kt
+++ b/core/datastore/src/main/java/com/looker/core/datastore/model/Theme.kt
@@ -2,7 +2,7 @@ package com.looker.core.datastore.model
 
 enum class Theme {
 	SYSTEM,
-	SYSTEM_BLACK,
+	SYSTEM_AMOLED,
 	LIGHT,
 	DARK,
 	AMOLED


### PR DESCRIPTION
Added theme files for the app that use the "Material You" colors made available in API 31 as was brought up in issue #186. It should not affect users on older versions of Android. I believe I properly adjusted the palette brightness options to still maintain the same contrast between the different colors, although I obviously can't account for all material-you color palettes. Please let me know if there are any issues with contrast or if further changes are required. I am not too familiar with android specific Java/Kotlin development these days, so I tried not to touch more than I needed to just get it working for now. 

#### Considerations for further revision:
- ~~As of the first iteration of this pull request, it overwrites all the theme colors that can be gotten from the @android:color palettes, although I may want to make it a toggle-able option if users want the current existing colors instead of the "material you" ones.~~ 
  - Fixed: now only uses the Material-You themes when using the "SYSTEM" or "SYSTEM_AMOLED" theme settings preferences.
- ~~Additionally, the new themes are currently just a drop in duplicates of the various theme options with the relevant colors changed to the system material-you ones. Ideally, these theme files would be theme overlays that inherit the colors that are common between each other from a parent theme and overwrite, as to avoid duplication of configuration code and ease of further iteration. I noticed that the Dark and Black theme versions didn't already do this, so perhaps this is a refactor that should be saved for another pull request.~~ 
  - FIXED: now, the Material-You themes are separate theme style overlays that inherent their non-material-you properties from their respective original themes.

#### Testing:
- Tested working on a P6 Pro running API 33. 
- Tested working on a P6 Pro running API 30 to verify that the original theme styles are chosen if on an Android version prior to the dynamic color options. 
- No new bugs observed 

---
#### Changes:
- Added an additional `styles.xml` file that uses the dynamic system colors only available when on devices with API31+.
- Additionally refactored the Theme enum option name 'SYSTEM_BLACK' to 'SYSTEM_AMOLED' to make it consistent with the other option 'AMOLED'. This can be undone if not desired.
- Made dynamic "material-you" theme styles into their own separate themes that extend from their non-dynamic colored parents to avoid duplicate code.
- Changed `Preferences.kt`  to use the dynamic colored theme styles when choosing the 'SYSTEM' & 'SYSTEM_AMOLED' theme settings options, depending on if the SDK version is at least 31. 
  - Imported the object `com.looker.core.common.Util`  to accomplish the above changes in `Preferences.kt`

---
#### Screenshots:

![Screenshot_20221231_215702](https://user-images.githubusercontent.com/16065962/210159861-e359d1ed-6dff-4244-8237-e70a6dc38307.png)
![Screenshot_20221231_215737](https://user-images.githubusercontent.com/16065962/210159865-be0a03f4-70c3-490f-8464-47558b876776.png)
![Screenshot_20221231_215833](https://user-images.githubusercontent.com/16065962/210159867-6a6a6982-e1b3-404b-8e4c-a45ee7c5f5de.png)
![Screenshot_20221231_215901](https://user-images.githubusercontent.com/16065962/210159869-ce9f4aca-0bb7-4d82-a8ac-f7d07620648c.png)