### PR TITLE
Finish up MD3 preferences migration

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -43,9 +43,9 @@ import coil.load
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.imageview.ShapeableImageView
+import com.google.android.material.materialswitch.MaterialSwitch
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.switchmaterial.SwitchMaterial
 import com.looker.core.common.extension.getColorFromAttr
 import com.looker.core.common.extension.getDrawableCompat
 import com.looker.core.common.extension.inflate
@@ -410,7 +410,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 	}
 
 	private class SwitchViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-		val enabled = itemView.findViewById<SwitchMaterial>(R.id.update_state_switch)!!
+		val enabled = itemView.findViewById<MaterialSwitch>(R.id.update_state_switch)!!
 
 		val statefulViews: Sequence<View>
 			get() = sequenceOf(itemView, enabled)

--- a/app/src/main/res/layout/switch_item.xml
+++ b/app/src/main/res/layout/switch_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.switchmaterial.SwitchMaterial xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.materialswitch.MaterialSwitch xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/update_state_switch"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/switch_type.xml
+++ b/app/src/main/res/layout/switch_type.xml
@@ -27,9 +27,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/title" />
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
+    <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/checked"
-        style="?switchStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/core/common/src/main/res/values/styles.xml
+++ b/core/common/src/main/res/values/styles.xml
@@ -36,6 +36,7 @@
         <item name="switchStyle">@style/Theme.Switch</item>
         <item name="toolbarStyle">@style/Theme.Toolbar</item>
         <item name="textInputStyle">@style/Theme.EditText</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
         <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
         <item name="materialCardViewStyle">@style/Theme.Card</item>
         <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
@@ -73,6 +74,7 @@
         <item name="switchStyle">@style/Theme.Switch</item>
         <item name="toolbarStyle">@style/Theme.Toolbar</item>
         <item name="textInputStyle">@style/Theme.EditText</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
         <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
         <item name="materialCardViewStyle">@style/Theme.Card</item>
         <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
@@ -110,6 +112,7 @@
         <item name="switchStyle">@style/Theme.Switch</item>
         <item name="toolbarStyle">@style/Theme.Toolbar</item>
         <item name="textInputStyle">@style/Theme.EditText</item>
+        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
         <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
         <item name="materialCardViewStyle">@style/Theme.Card</item>
         <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
@@ -146,6 +149,10 @@
 
     <style name="Theme.Toolbar" parent="Widget.Material3.Toolbar.Surface">
         <item name="layout_collapseMode">pin</item>
+    </style>
+
+    <style name="Theme.Alert" parent="ThemeOverlay.Material3.MaterialAlertDialog.Centered">
+        <item name="android:dialogCornerRadius" tools:targetApi="p">@dimen/shape_large_corner</item>
     </style>
 
     <style name="Theme.EditText" parent="Widget.Material3.TextInputLayout.FilledBox">

--- a/core/common/src/main/res/values/styles.xml
+++ b/core/common/src/main/res/values/styles.xml
@@ -36,7 +36,6 @@
         <item name="switchStyle">@style/Theme.Switch</item>
         <item name="toolbarStyle">@style/Theme.Toolbar</item>
         <item name="textInputStyle">@style/Theme.EditText</item>
-        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
         <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
         <item name="materialCardViewStyle">@style/Theme.Card</item>
         <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
@@ -74,7 +73,6 @@
         <item name="switchStyle">@style/Theme.Switch</item>
         <item name="toolbarStyle">@style/Theme.Toolbar</item>
         <item name="textInputStyle">@style/Theme.EditText</item>
-        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
         <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
         <item name="materialCardViewStyle">@style/Theme.Card</item>
         <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
@@ -112,7 +110,6 @@
         <item name="switchStyle">@style/Theme.Switch</item>
         <item name="toolbarStyle">@style/Theme.Toolbar</item>
         <item name="textInputStyle">@style/Theme.EditText</item>
-        <item name="materialAlertDialogTheme">@style/Theme.Alert</item>
         <item name="appBarLayoutStyle">@style/Theme.AppBarLayout</item>
         <item name="materialCardViewStyle">@style/Theme.Card</item>
         <item name="materialCardViewElevatedStyle">@style/Theme.Card.Elevated</item>
@@ -149,13 +146,6 @@
 
     <style name="Theme.Toolbar" parent="Widget.Material3.Toolbar.Surface">
         <item name="layout_collapseMode">pin</item>
-    </style>
-
-    <style name="Theme.Alert" parent="ThemeOverlay.Material3.MaterialAlertDialog.Centered">
-        <item name="colorPrimary">?attr/colorOnSurface</item>
-        <item name="android:dialogCornerRadius" tools:targetApi="p">@dimen/shape_large_corner</item>
-        <item name="android:backgroundTint">?attr/colorSurface</item>
-        <item name="colorOnSurfaceVariant">?attr/colorOnSurface</item>
     </style>
 
     <style name="Theme.EditText" parent="Widget.Material3.TextInputLayout.FilledBox">


### PR DESCRIPTION
Hey,
thanks for the awesome app!
With this PR I'm aiming to improve the preferences UI a bit by moving some stuff to Material Design 3.

* Use [Material Design 3 switches](https://m3.material.io/components/switch/overview) instead of the ones from MD2 in the preferences
* Fix the background color of preference dialogs (by removing legacy code which has only been needed before all `AlertDialog` occurrences got replaced with the `MaterialAlertDialogBuilder`)

Fyi, I've tested the changes on an Android 13 device.
Have a good one!